### PR TITLE
Fix parsing of remote IP

### DIFF
--- a/django_simple_ip_restrict/middleware.py
+++ b/django_simple_ip_restrict/middleware.py
@@ -34,7 +34,7 @@ def ip_filter(get_response):
             pass
         else:
             if not protected_namespaces.isdisjoint(resolver_match.namespaces):
-                ip_address = IPAddress(request.META["HTTP_X_FORWARDED_FOR"])
+                ip_address = IPAddress(request.META["HTTP_X_FORWARDED_FOR"].split(",")[0])
                 if not any(ip_address in subnet for subnet in whitelist):
                     logger.warn(
                         "IP %s tried to access protected url %s",

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -6,6 +6,6 @@ class TestFirewall(TestCase):
         response = self.client.get("/admin/", HTTP_X_FORWARDED_FOR="83.4.12.1")
         self.assertEqual(response.status_code, 403)
 
-    def test_firewall(self):
+    def test_multiple_ips(self):
         response = self.client.get("/admin/", HTTP_X_FORWARDED_FOR="83.4.12.1, 10.2.1.1")
         self.assertEqual(response.status_code, 403)

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -5,3 +5,7 @@ class TestFirewall(TestCase):
     def test_firewall(self):
         response = self.client.get("/admin/", HTTP_X_FORWARDED_FOR="83.4.12.1")
         self.assertEqual(response.status_code, 403)
+
+    def test_firewall(self):
+        response = self.client.get("/admin/", HTTP_X_FORWARDED_FOR="83.4.12.1, 10.2.1.1")
+        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
For some clients, more than one IP may be passed on the X-FORWARDED-FOR header, an internal and an external one. We just care about the latter.